### PR TITLE
DockerPushApp deployment type to allow for rolling deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,10 +153,10 @@ utility on a server.
       | dockerOrganization     | Docker organization name.                   |
       | dockerName             | Docker image name.                          |
       | dockerTag              | Docker image tag.                           |
-	  | pullDockerUrl          | Docker base url to do a 'docker pull' from. |
-	  | pullDockerOrganization | Docker organization name to pull.           |
-	  | pullDockerName         | Docker image name to pull.                  |
-	  | pullDockerTag          | Docker image tag to pull.                   |
+      | pullDockerUrl          | Docker base url to do a 'docker pull' from. |
+      | pullDockerOrganization | Docker organization name to pull.           |
+      | pullDockerName         | Docker image name to pull.                  |
+      | pullDockerTag          | Docker image tag to pull.                   |
 
     * **openshift.BinaryApp:**
       An OpenShift Binary App is an actual container file that should be deployed to a OpenShift project.  The Binary App module is defined as follows:

--- a/README.md
+++ b/README.md
@@ -27,27 +27,27 @@ This XLD OpenShift plugin supports v2 & v3 OpenShift implementations.  This plug
 
 * **Requirements**
 	* From version v7.x+, XLD 6.x is required.
-	* **Remark**: version v7.x+ breaks compatibility with previous versions! 
-	* **rhc client on target machine for OpenShift v2** 
-	* **oc client on target machine for OpenShift v3** 
+	* **Remark**: version v7.x+ breaks compatibility with previous versions!
+	* **rhc client on target machine for OpenShift v2**
+	* **oc client on target machine for OpenShift v3**
 
 # Installation #
 
-Place the plugin xldp file into your `SERVER_HOME/plugins` directory.  For OpenShift v3 you will also need to install the [CLI](https://docs.openshift.org/latest/cli_reference/get_started_cli.html) 
-utility on a server. 
+Place the plugin xldp file into your `SERVER_HOME/plugins` directory.  For OpenShift v3 you will also need to install the [CLI](https://docs.openshift.org/latest/cli_reference/get_started_cli.html)
+utility on a server.
 
 
 # Usage #
 
-## OpenShift v3 
+## OpenShift v3
 
 * OpenShift Containers
 
 	* **openshift.Server**
 	   The `openshift.server` represents the OpenShift server and is the container where the open shift `oc` commands will be exectued.  The `openshift.Server` container object is defined as follows:
-	   
+
 	   `openshift.Server` extends `udm.BaseContainer`
-	   
+
 	   | Properties     |           Description                                               |
 	   |----------------|---------------------------------------------------------------------|
 	   | host           | `overthere.Host` that contains the `openshift.Server`               |
@@ -61,9 +61,9 @@ utility on a server.
 	   | password       | The password to authenticate to the OpenShift server                |
 	   | openshiftToken | An OpenShift token for token authentication                         |
 	   | credential     | A Custom `openshift.Credential` type                                |
-	   
+
 	   Depending on the authentication method some of the properties will be required.  Required properties for specific authentication methods are as follows:
-	   
+
 	   * **BASIC:**
 	      * Username
 	      * password
@@ -76,15 +76,15 @@ utility on a server.
 	   * **Token Alias:**
 	      * credential `openshift.Credential`
 	         * Token
-	   
+
 	   The `openshift.Server` has two control tasks that can be use to verify the configuration as follows:
 	   * ***check:*** This control task will log into the OpenShift server using the **oc** command line tool to verify connectivity to the OpenShift server.
 	   * **showResource:** This control task can be use to check on the available resources for a project.  You will be expect to provide a project name to execute this control task.
-	   
+
 	   **Note**
        To install the `oc` client, on Unix hosts, the plugin will use `wget`that should be already installed.
        On Windows hosts, there are 2 options
-       
+
        * use a version of `wget` bundled in the plugin and uploaded to perform the http request. (default option)
        * use a _different_ `wget` that is _already present_ on the path of your target systems you can simply prevent the included version from being uploaded by modifying `SERVER_HOME/conf/deployit-defaults.properties` as follows:
        ```
@@ -96,12 +96,12 @@ utility on a server.
        	# Classpath Resources
        	openshift.Server.wgetExecutable=[Put your path here]
 	   ```
-	   
+
     * **openshift.Project**
        An OpenShift project.  The project module is defined as follows:
-    
+
        `openshift.Project` extends `udm.BaseContainer`
-    
+
        | Properties      |         Description                      |
        |-----------------|------------------------------------------|
        | projectName     | A name for the project                   |
@@ -111,9 +111,9 @@ utility on a server.
 * OpenShift Provisionables
     * **openshift.openshift.ProjectSpec**
        An OpenShift project spec.  The project spec is defined as follows:
-    
+
        `openshift.ProjectSpec` extends `udm.BaseProvisionable`
-    
+
        | Properties      |         Description                      |
        |-----------------|------------------------------------------|
        | projectName     | A name for the project                   |
@@ -121,12 +121,12 @@ utility on a server.
        | projectDisplayName | A human readable name for the project |
 
 * OpenShift Deployables
-	       
+
     * **openshift.App**
        The OpenShift App is a container image that can be deployed from a registry.  By default XLD will deploy container images from the Docker Hub, but it is possible to supply and internal URL for a local repository.  The App module is defined as follows:
-       
+
        `openshift.App` extends `udm.BaseDeployable`
-       
+
        | Properties         |        Description                |
        |--------------------|-----------------------------------|
        | `Common`           | --------------------------------  |
@@ -137,43 +137,63 @@ utility on a server.
        | dockerOrganization | Docker organization name.         |
        | dockerName         | Docker image name.                |
        | dockerTag          | Docker image tag.                 |
-       
+
+   * **openshift.DockerPushApp**
+      The OpenShift DockerPushApp is similar to the openshift.App in that it is a container image that can be deployed from a registry.  The difference is that there is a docker pull to pull it from a central repository, tag the image, and then a push operation, pushing the image into Openshift.  This triggers a rolling deployment which is monitored by the plugin.   The DockerPushApp module is defined as follows:
+
+      `openshift.DockerPushApp` extends `udm.BaseDeployable`
+
+      | Properties             |            Description                      |
+      |------------------------|---------------------------------------------|
+      | `Common`               | ------------------------------------------  |
+      | appName                | OpenShift application name                  |
+      | project                | OpenShift project name.                     |
+      | `Docker`               | ------------------------------------------  |
+      | dockerUrl              | Docker base url to be used.                 |
+      | dockerOrganization     | Docker organization name.                   |
+      | dockerName             | Docker image name.                          |
+      | dockerTag              | Docker image tag.                           |
+	  | pullDockerUrl          | Docker base url to do a 'docker pull' from. |
+	  | pullDockerOrganization | Docker organization name to pull.           |
+	  | pullDockerName         | Docker image name to pull.                  |
+	  | pullDockerTag          | Docker image tag to pull.                   |
+
     * **openshift.BinaryApp:**
       An OpenShift Binary App is an actual container file that should be deployed to a OpenShift project.  The Binary App module is defined as follows:
-      
+
       `openshift.BinaryAppModule` extends `udm.BaseDeployableArtifact`
-      
+
       |  Properties         |       Description                 |
       |---------------------|-----------------------------------|
       | appName             | OpenShift application name        |
       | project             | OpenShift project name.           |
       | imageStream         | The input stream to use as the builder |
-      
+
     * **openshift.DockerfileApp:**
       An OpenShift Docker App is an actual Dockerfile that should be deployed to a OpenShift project.  The Dockerfile app module is defined as follows:
-      
+
       `openshift.DockerfileAppModule` extends `udm.BaseDeployableArtifact`
-      
+
       |  Properties         |       Description                 |
       |---------------------|-----------------------------------|
       | appName             | OpenShift application name        |
       | project             | OpenShift project name.           |
-      
+
     * **openshift.ResourceModule:** The resource module defines the resources availble to the project.  The definition of the resources are defined in a YAML file attached to this deployable.  The Resource Modules is defined as follows:
-    
+
       `openshift.ResourceModule` extends `udm.BaseDeployableArtifact`
-    
+
       |  Properties         |       Description                 |
       |---------------------|-----------------------------------|
       | project             | OpenShift Project name            |
       | resourceYml         | YML file defining the resources   |
-         
-    
-    
+
+
+
 * OpenShift v2
 
 # References #
 + CLI operations: [Basic intro](https://docs.openshift.org/latest/cli_reference/basic_cli_operations.html)
 + Blue-green: [Blue green deployments](https://blog.openshift.com/openshift-3-demo-part-10-blue-green-deployments/)
-+ Routes: 
++ Routes:
     + [cli](https://docs.openshift.com/container-platform/latest/dev_guide/routes.html)

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ xlDocker {
   runPortMapping = '14516:4516'
 }
 
-version = "7.0.0"
+version = "7.1.0"
 
 apply plugin: 'java'
 apply plugin: 'idea'

--- a/src/main/resources/openshift/docker-pull-tag-push.sh.ftl
+++ b/src/main/resources/openshift/docker-pull-tag-push.sh.ftl
@@ -1,0 +1,18 @@
+<#--
+
+    THIS CODE AND INFORMATION ARE PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS
+    FOR A PARTICULAR PURPOSE. THIS CODE AND INFORMATION ARE NOT SUPPORTED BY XEBIALABS.
+
+-->
+#!/bin/sh
+set -e
+
+DOCKER_FROM=<#if deployed.pullDockerUrl?has_content>${deployed.pullDockerUrl}/</#if><#if deployed.pullDockerOrganization?has_content>${deployed.pullDockerOrganization}/</#if>${deployed.pullDockerName}<#if deployed.pullDockerTag?has_content>:${deployed.pullDockerTag}</#if>
+DOCKER_TO=<#if deployed.dockerUrl?has_content>${deployed.dockerUrl}/</#if><#if deployed.dockerOrganization?has_content>${deployed.dockerOrganization}/</#if>${deployed.dockerName}<#if deployed.dockerTag?has_content>:${deployed.dockerTag}</#if>
+
+echo "Pulling image from:  $DOCKER_FROM"
+echo "  Pushing image to:  $DOCKER_TO"
+docker pull $DOCKER_FROM
+docker tag $DOCKER_FROM $DOCKER_TO
+docker push $DOCKER_TO

--- a/src/main/resources/openshift/verify-deployment.sh.ftl
+++ b/src/main/resources/openshift/verify-deployment.sh.ftl
@@ -1,0 +1,59 @@
+<#--
+
+    THIS CODE AND INFORMATION ARE PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS
+    FOR A PARTICULAR PURPOSE. THIS CODE AND INFORMATION ARE NOT SUPPORTED BY XEBIALABS.
+
+-->
+#!/bin/sh
+set -e
+
+#############
+# Variables #
+#############
+OC=${deployed.container.server.ocHome}/oc
+TIME_INCREMENT=5    # How often to check on the deployment
+TIMEOUT_MAX=1200    # How long to wait for a deployment to finish before declaring failure
+
+
+<#assign container=deployed.container.server />
+<#include "/openshift/oc-login-container.ftl">
+
+$OC project ${deployed.container.projectName}
+
+#Find the Replication Controller to watch
+RC=${deployed.appName}-$($OC get dc ${deployed.appName} --template='{{range $index,$element := .}}{{if eq $index "status"}}{{range $index2,$element2 := .}}{{if eq $index2 "latestVersion"}}{{$element2}}{{end}}{{end}}{{end}}{{end}}')
+
+echo "Watching $RC"
+
+# Main script loop.  Loop from 0 to TIMEOUT_MAX counting by TIME_INCREMENT
+for TIME in $(seq 0 $TIME_INCREMENT $TIMEOUT_MAX)
+do
+    STATUS=$($OC get rc $RC --template='{{$replicas := .status.fullyLabeledReplicas}}{{range $index,$element := .metadata.annotations}}{{if eq $index "openshift.io/deployment.phase"}}{{println $element "- Deploying Pod:" $replicas}}{{end}}{{end}}')
+    echo $STATUS
+
+    # f it is complete, all is well with the deployment
+    if [[ $STATUS =~ "Complete" ]]; then
+        echo "Deployment Success"
+        $OC status
+        $OC logout
+        exit 0
+    fi
+
+    if [[ $STATUS =~ "Failed" ]]; then
+        echo "Deployment failure"
+        $OC status
+        $OC logout
+        exit 99
+    fi
+
+    # If we don't have 'Complete' or 'Failed' yet, it is in 'Pending' or 'Running' mode.  Keep waiting
+    sleep $TIME_INCREMENT
+
+done
+
+# If we have made it here, TIMEOUT_MAX has been reached. Declare the deployment a failure
+echo "Deployment Timed Out"
+$OC status
+$OC logout
+exit 99

--- a/src/main/resources/synthetic.xml
+++ b/src/main/resources/synthetic.xml
@@ -75,6 +75,24 @@
         <property name="dockerTag" required="false" label="Docker Image Tag" category="Docker" description="Docker image tag."/>
     </type>
 
+    <type type="openshift.DockerPushAppModule" extends="udm.BaseDeployed" deployable-type="openshift.DockerPushApp"
+          container-type="openshift.Project" description="OpenShift Docker Push App">
+        <generate-deployable type="openshift.DockerPushApp" extends="udm.BaseDeployable"/>
+        <property name="appName" required="true"/>
+        <property name="blueGreen" kind="boolean" required="false" default="false" description="If selected, an update operation will be performed in a blue green deployment." />
+
+
+        <property name="dockerUrl" required="false" label="Docker Url" category="Docker" description="Docker base url to be used."/>
+        <property name="dockerOrganization" required="false" label="Docker Organization" category="Docker" description="Docker organization name."/>
+        <property name="dockerName" required="false" label="Docker Image Name" category="Docker" description="Docker image name."/>
+        <property name="dockerTag" required="false" label="Docker Image Tag" category="Docker" description="Docker image tag."/>
+
+        <property name="pullDockerUrl" required="false" label="Pull Docker Url" category="Docker" description="Docker base url to do a 'docker pull' from."/>
+        <property name="pullDockerOrganization" required="true" label="Pull Docker Organization" category="Docker" description="Docker organization name to pull."/>
+        <property name="pullDockerName" required="true" label="Pull Docker Image Name" category="Docker" description="Docker image name to pull."/>
+        <property name="pullDockerTag" required="false" label="Pull Docker Image Tag" category="Docker" description="Docker image tag to pull."/>
+    </type>
+
     <type type="openshift.BinaryAppModule" extends="udm.BaseDeployedArtifact" deployable-type="openshift.BinaryApp"
           container-type="openshift.Project" description="OpenShift Binary App">
         <generate-deployable type="openshift.BinaryApp" extends="udm.BaseDeployableArtifact"/>

--- a/src/main/resources/xl-rules.xml
+++ b/src/main/resources/xl-rules.xml
@@ -39,6 +39,7 @@
     <rule name="openshift.AppModule.CREATE" scope="deployed">
         <conditions>
             <type>openshift.AppModule</type>
+            <type>openshift.DockerPushAppModule</type>
             <operation>CREATE</operation>
         </conditions>
         <steps>
@@ -63,6 +64,7 @@
     <rule name="openshift.AppModule.DESTROY" scope="deployed">
         <conditions>
             <type>openshift.AppModule</type>
+            <type>openshift.DockerPushAppModule</type>
             <operation>DESTROY</operation>
         </conditions>
         <steps>
@@ -133,6 +135,35 @@
                 <freemarker-context>
                     <operation>modify</operation>
                 </freemarker-context>
+            </os-script>
+        </steps>
+    </rule>
+
+    <rule name="openshift.DockerPushAppModule.push-pull.CREATE" scope="deployed">
+        <conditions>
+            <type>openshift.DockerPushAppModule</type>
+            <operation>CREATE</operation>
+            <operation>MODIFY</operation>
+        </conditions>
+        <steps>
+            <os-script>
+                <script>openshift/docker-pull-tag-push</script>
+                <description expression="true">"Pulling [%s]:[%s] from the Registry and pushing to OpenShift" % (deployed.pullDockerName, deployed.pullDockerTag)</description>
+                <order>60</order>
+                <target-host expression="true">deployed.container.server.host</target-host>
+            </os-script>
+
+            <wait>
+                <order>65</order>
+                <description>Pause to let the change image trigger the deployment</description>
+                <seconds>10</seconds>
+            </wait>
+
+            <os-script>
+                <script>openshift/verify-deployment</script>
+                <description expression="true">"Verifying Rolling Deployment of [%s]" % (deployed.appName)</description>
+                <order>66</order>
+                <target-host expression="true">deployed.container.server.host</target-host>
             </os-script>
         </steps>
     </rule>

--- a/src/test/resources/docker/docker-compose.yml
+++ b/src/test/resources/docker/docker-compose.yml
@@ -22,6 +22,6 @@ xld:
   image: xebialabs/xld_dev_run:v6.1.0.1
   volumes:
     - ~/xl-licenses:/license
-    - ~/xl-data:/data
+    - ./../../../../:/data
   ports:
    - "14516:4516"

--- a/src/test/resources/docker/docker-compose.yml
+++ b/src/test/resources/docker/docker-compose.yml
@@ -22,6 +22,6 @@ xld:
   image: xebialabs/xld_dev_run:v6.1.0.1
   volumes:
     - ~/xl-licenses:/license
-    - ./../../../../:/data
+    - ~/xl-data:/data
   ports:
    - "14516:4516"


### PR DESCRIPTION
Added a DockerPushApp type.  This type uses a "from" docker registry, either an internal registry, or a site like docker hub.  It pulls the images with docker pull, tags them with the image name that is used by App type.  When this image is changed, it triggers OpenShift's rolling deployment performing the deployment without service outage.  verify-deployment.sh.ftl watches this deployment happen reporting the success or failure that OpenShift returns.