### PR TITLE
Renaming 'openshift' types to 'ose'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 
-version="6.0.0.RC9"
+version="7.1.1"
 
 apply plugin: 'java'
 apply plugin: 'idea'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'xld-openshift-plugin'
+rootProject.name = 'xld-ose-plugin'

--- a/src/main/resources/synthetic.xml
+++ b/src/main/resources/synthetic.xml
@@ -11,7 +11,7 @@
 
     <!-- OpenShift v3 -->
     <!-- v3 container -->
-    <type type="openshift.Server" extends="udm.BaseContainer">
+    <type type="ose.Server" extends="udm.BaseContainer">
         <property name="host" kind="ci" referenced-type="overthere.Host" as-containment="true" description="The host where the oc client is installed on."/>
         <property name="serverUrl" required="true"/>
         <property name="ocHome" required="true"/>
@@ -22,18 +22,18 @@
 
     <!-- v3 deployables -->
     <!-- v3 project - should already exist. -->
-    <type type="openshift.ProjectModule" extends="udm.BaseDeployed" deployable-type="openshift.Project"
-          container-type="openshift.Server" description="OpenShift Project">
-        <generate-deployable type="openshift.Project" extends="udm.BaseDeployable"/>
+    <type type="ose.ProjectModule" extends="udm.BaseDeployed" deployable-type="ose.Project"
+          container-type="ose.Server" description="ose Project">
+        <generate-deployable type="ose.Project" extends="udm.BaseDeployable"/>
         <property name="projectName" required="true"/>
         <property name="description" required="false"/>
         <property name="projectDisplayName" required="false"/>
     </type>
 
     <!-- v3 app -->
-    <type type="openshift.AppModule" extends="udm.BaseDeployed" deployable-type="openshift.App"
-          container-type="openshift.Server" description="OpenShift App">
-        <generate-deployable type="openshift.App" extends="udm.BaseDeployable"/>
+    <type type="ose.AppModule" extends="udm.BaseDeployed" deployable-type="ose.App"
+          container-type="ose.Server" description="ose App">
+        <generate-deployable type="ose.App" extends="udm.BaseDeployable"/>
         <property name="appName" required="true"/>
         <property name="project" required="true"/>
         <property name="dockerUrl" required="false" category="Docker"/>

--- a/src/main/resources/xl-rules.xml
+++ b/src/main/resources/xl-rules.xml
@@ -8,9 +8,9 @@
 
 <rules xmlns="http://www.xebialabs.com/xl-deploy/xl-rules">
 
-    <rule name="openshift.ProjectModule.CREATE_MODIFY" scope="deployed">
+    <rule name="ose.ProjectModule.CREATE_MODIFY" scope="deployed">
         <conditions>
-            <type>openshift.ProjectModule</type>
+            <type>ose.ProjectModule</type>
             <operation>CREATE</operation>
             <operation>MODIFY</operation>
         </conditions>
@@ -22,9 +22,9 @@
         </steps>
     </rule>
 
-    <rule name="openshift.ProjectModule.DESTROY" scope="deployed">
+    <rule name="ose.ProjectModule.DESTROY" scope="deployed">
         <conditions>
-            <type>openshift.ProjectModule</type>
+            <type>ose.ProjectModule</type>
             <operation>DESTROY</operation>
         </conditions>
         <steps>
@@ -35,9 +35,9 @@
         </steps>
     </rule>
 
-    <rule name="openshift.AppModule.CREATE_MODIFY" scope="deployed">
+    <rule name="ose.AppModule.CREATE_MODIFY" scope="deployed">
         <conditions>
-            <type>openshift.AppModule</type>
+            <type>ose.AppModule</type>
             <operation>CREATE</operation>
             <operation>MODIFY</operation>
         </conditions>
@@ -49,9 +49,9 @@
         </steps>
     </rule>
 
-    <rule name="openshift.AppModule.DESTROY" scope="deployed">
+    <rule name="ose.AppModule.DESTROY" scope="deployed">
         <conditions>
-            <type>openshift.AppModule</type>
+            <type>ose.AppModule</type>
             <operation>DESTROY</operation>
             <operation>MODIFY</operation>
         </conditions>


### PR DESCRIPTION
We need to run this community edition (legacy) plugin concurrently with the current version of xld-openshift-plugin that is now provided by xebia.  In order to do so, we need to remove conflicting type names.  I have renamed openshift.* types to ose.* types.